### PR TITLE
Remove mailinglist

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,27 +44,6 @@
       </section>
 
       <section>
-        <div id="mc_embed_signup">
-          <form action="//polyglots.us9.list-manage.com/subscribe/post?u=bb4a32ee8e473689c1da6524e&amp;id=fe24d3fc8f" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-            <h3><span class="glyphicon glyphicon-envelope"></span> Mailing List</h3>
-            <p>Subscribe to our mailing list to get notifications about future meetups</p>
-            <div class="input-group mc-field-group">
-              <span class="input-group-addon">Email</span>
-              <input type="email" value="" name="EMAIL" id="mcd-EMAIL" class="form-control">
-              <span class="input-group-btn">
-                <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-default">
-              </span>
-            </div>
-            <div id="mce-responses" class="clear">
-              <div class="response" id="mce-error-response" style="display:none"></div>
-              <div class="response" id="mce-success-response" style="display:none"></div>
-            </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;"><input type="text" name="b_bb4a32ee8e473689c1da6524e_fe24d3fc8f" tabindex="-1" value=""></div>
-          </form>
-        </div>
-      </section>
-
-      <section>
         <h3><span class="glyphicon glyphicon-calendar"></span> Upcoming Events</h3>
 
         <!--<p>We currently don't have an upcoming event scheduled</p>-->


### PR DESCRIPTION
Sorry if I just remove things left and right but I would like to make it easier to organize things and cross-announcing things on all kinds of mediums is a lot of effort so I think it would be nicer if we concentrated on the channels which are most used.

I totally see the usecase of not wanting to use Meetup, so instead I would propose to replace the mailing list with an RSS feed, like the one TwitRSS offers: https://twitrss.me/twitter_user_to_rss/?user=polyglotsdk